### PR TITLE
Add a `maxItems` parameter

### DIFF
--- a/Release Notes.md
+++ b/Release Notes.md
@@ -1,5 +1,6 @@
 # Release Notes
 
+* v1.2.2: Pagination Helper updated to 1.7.2
 * v1.2.1: Bugfix for using `customSort` and `customApply` at the same time (Pagination Helper)
 * v1.2.0: Allow custom apply-templates in Pagination Helper
 * v1.1.0: Customize classes in Pagination Helper
@@ -32,8 +33,8 @@
 
 ## MultiPicker Helper
 
-* v1.0: Included in package
 * v1.1: Added support for MNTP for Media nodes
+* v1.0: Included in package
 
 ## Navigation Helper
 
@@ -41,6 +42,7 @@
 
 ## Pagination Helper
 
+* v1.7.2: Add `$maxItems` parameter
 * v1.7.1: Bugfix for custom apply with custom sort 
 * v1.7: Support custom apply in pagination
 * v1.6: Add class variables for `.pager`, `.prev`, `.next` and `.current`

--- a/dist/xslt/helpers/_CalendarHelper.xslt
+++ b/dist/xslt/helpers/_CalendarHelper.xslt
@@ -3,7 +3,7 @@
 	<!-- You need to set this to the name of the property/attribute on your event nodes that holds the "date" value -->
 	<!ENTITY eventDate "eventStartDateTime">
 ]>
-<?umbraco-package XSLT Helpers v1.2.1 - CalendarHelper v1.2?>
+<?umbraco-package XSLT Helpers v1.2.2 - CalendarHelper v1.2?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:umb="urn:umbraco.library" xmlns:freeze="http://xmlns.greystate.dk/2012/freezer" xmlns:date="urn:Exslt.ExsltDatesAndTimes" xmlns:make="urn:schemas-microsoft-com:xslt" version="1.0" exclude-result-prefixes="umb date make freeze">
 
 	<!-- Grab today's date - we probably need it, this being a calendar and all -->

--- a/dist/xslt/helpers/_GroupingHelper.xslt
+++ b/dist/xslt/helpers/_GroupingHelper.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?umbraco-package XSLT Helpers v1.2.1 - GroupingHelper v1.0?>
+<?umbraco-package XSLT Helpers v1.2.2 - GroupingHelper v1.0?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
 	<!-- 'Groupify' template -->

--- a/dist/xslt/helpers/_MediaHelper.xslt
+++ b/dist/xslt/helpers/_MediaHelper.xslt
@@ -8,7 +8,7 @@
 	
 	Enables simple retrieval of media by handling the GetMedia() call and error-checking
 -->
-<?umbraco-package XSLT Helpers v1.2.1 - MediaHelper v2.0?>
+<?umbraco-package XSLT Helpers v1.2.2 - MediaHelper v2.0?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:umb="urn:umbraco.library" xmlns:freeze="http://xmlns.greystate.dk/2012/freezer" xmlns:get="urn:Exslt.ExsltMath" xmlns:make="urn:schemas-microsoft-com:xslt" version="1.0" exclude-result-prefixes="umb get make freeze">
 
 	

--- a/dist/xslt/helpers/_MultiPickerHelper.xslt
+++ b/dist/xslt/helpers/_MultiPickerHelper.xslt
@@ -4,7 +4,7 @@
 
 	Helper file for rendering various datatypes that store node ids.
 -->
-<?umbraco-package XSLT Helpers v1.2.1 - MultiPickerHelper v1.1?>
+<?umbraco-package XSLT Helpers v1.2.2 - MultiPickerHelper v1.1?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:umb="urn:umbraco.library" version="1.0" exclude-result-prefixes="umb">
 
 	<xsl:key name="document-by-id" match="*[@isDoc]" use="@id"/>

--- a/dist/xslt/helpers/_NavigationHelper.xslt
+++ b/dist/xslt/helpers/_NavigationHelper.xslt
@@ -3,7 +3,7 @@
 	<!-- You can change this to suit your environment -->
 	<!ENTITY subPages "*[@isDoc][not(@template = 0) and not(umbracoNaviHide = 1)]">
 ]>
-<?umbraco-package XSLT Helpers v1.2.1 - NavigationHelper v1.2?>
+<?umbraco-package XSLT Helpers v1.2.2 - NavigationHelper v1.2?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:umb="urn:umbraco.library" xmlns:freeze="http://xmlns.greystate.dk/2012/freezer" version="1.0" exclude-result-prefixes="umb freeze">
 
 <!-- :: Configuration :: -->

--- a/dist/xslt/helpers/_PaginationHelper.xslt
+++ b/dist/xslt/helpers/_PaginationHelper.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?umbraco-package XSLT Helpers v1.2.1 - PaginationHelper v1.7.1?>
+<?umbraco-package XSLT Helpers v1.2.2 - PaginationHelper v1.7.2?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:umb="urn:umbraco.library" xmlns:str="urn:Exslt.ExsltStrings" xmlns:make="urn:schemas-microsoft-com:xslt" version="1.0" exclude-result-prefixes="umb str make">
 
 	<!-- Config constants -->
@@ -49,6 +49,9 @@
 		<!-- The stuff to paginate - defaults to all children of the context node when invoking this  -->
 		<xsl:param name="selection" select="*"/>
 		
+		<!-- Allow capping large sets of data by only showing a subset -->
+		<xsl:param name="maxItems" select="0"/>
+		
 		<!-- This is to allow forcing a specific page without using QueryString  -->
 		<xsl:param name="page" select="$page"/>
 		
@@ -80,7 +83,13 @@
 		<xsl:param name="nextClass" select="$nextClass"/>
 		
 		<xsl:variable name="startIndex" select="$perPage * ($page - 1) + 1"/><!-- First item on this page -->
-		<xsl:variable name="endIndex" select="$page * $perPage"/><!-- First item on next page -->
+		<xsl:variable name="endIndex"><!-- Last item on this page -->
+			<!--
+				If $maxItems is 0 use page * perPage
+				
+			-->
+			<xsl:value-of select="     (($page * $perPage) * (($maxItems = 0) or ($maxItems &gt; ($page * $perPage)))) +     (($maxItems) * (($page * $perPage) &gt;= $maxItems))    "/>
+		</xsl:variable>
 		
 		<xsl:choose>
 			<!-- Do we need to pre-sort the selection? -->
@@ -136,6 +145,7 @@
 	
 	<xsl:template name="RenderPager">
 		<xsl:param name="selection" select="*"/>
+		<xsl:param name="maxItems" select="0"/>
 		<xsl:param name="page" select="$page"/>
 		<xsl:param name="perPage" select="$perPage"/>
 		<xsl:param name="pageLinksBeside" select="$pageLinksBeside"/>
@@ -144,7 +154,7 @@
 		<xsl:param name="prevClass" select="$prevClass"/>
 		<xsl:param name="nextClass" select="$nextClass"/>
 		
-		<xsl:variable name="total" select="count($selection)"/>
+		<xsl:variable name="total" select="count($selection) * ($maxItems = 0) + $maxItems"/>
 		<xsl:variable name="lastPageNum" select="ceiling($total div $perPage)"/>
 		
 		<xsl:variable name="needToRenderGaps" select="$lastPageNum &gt; 2 * $pageLinksBeside + 4"/>

--- a/paginationhelper/README.md
+++ b/paginationhelper/README.md
@@ -144,6 +144,25 @@ get that from some other extension function. It assumes the standard query strin
 Also, there's a variable to hold the current page's URL - again, you can set it any way you like; the default uses Umbraco's
 `NiceUrl()` extension.
 
+### CSS
+
+The CSS classes used in the pager can also be customized - these are the defaults:
+
+```html
+<ul class="pager">
+	<li class="prev disabled"><span>Previous</span></li>
+	<li class="current"><span>1</span></li>
+	<li><a href="#">2</a></li>
+	<li><a href="#">3</a></li>
+	<li class="gap"><span>...</span></li>
+	<li><a href="#">9</a></li>
+	<li><a href="#">10</a></li>
+	<li class="next"><a href="#">Next</a></li>
+</ul>
+```
+
+The variables for these are located at the top of the file.
+
 ## Number of pages in the Pager output
 
 If the amount of pages grows huge, it's common to limit the pager output to some amount of pages *before* and *after* the current page.

--- a/paginationhelper/_PaginationHelper.xslt
+++ b/paginationhelper/_PaginationHelper.xslt
@@ -76,6 +76,9 @@
 		<!-- The stuff to paginate - defaults to all children of the context node when invoking this  -->
 		<xsl:param name="selection" select="*" />
 		
+		<!-- Allow capping large sets of data by only showing a subset -->
+		<xsl:param name="maxItems" select="0" />
+		
 		<!-- This is to allow forcing a specific page without using QueryString  -->
 		<xsl:param name="page" select="$page" />
 		
@@ -107,7 +110,23 @@
 		<xsl:param name="nextClass" select="$nextClass" />
 		
 		<xsl:variable name="startIndex" select="$perPage * ($page - 1) + 1" /><!-- First item on this page -->
-		<xsl:variable name="endIndex" select="$page * $perPage" /><!-- First item on next page -->
+		<xsl:variable name="endIndex"><!-- Last item on this page -->
+			<xsl:choose>
+				<xsl:when test="$maxItems = 0">
+					<xsl:value-of select="$page * $perPage" />
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:choose>
+						<xsl:when test="$page * $perPage &gt; $maxItems">
+							<xsl:value-of select="$maxItems" />
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="$page * $perPage" />
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
 		
 		<xsl:choose>
 			<!-- Do we need to pre-sort the selection? -->

--- a/paginationhelper/_PaginationHelper.xslt
+++ b/paginationhelper/_PaginationHelper.xslt
@@ -163,6 +163,7 @@
 	
 	<xsl:template name="RenderPager">
 		<xsl:param name="selection" select="*" />
+		<xsl:param name="maxItems" select="0" />
 		<xsl:param name="page" select="$page" />
 		<xsl:param name="perPage" select="$perPage" />
 		<xsl:param name="pageLinksBeside" select="$pageLinksBeside" />
@@ -171,7 +172,7 @@
 		<xsl:param name="prevClass" select="$prevClass" />
 		<xsl:param name="nextClass" select="$nextClass" />
 		
-		<xsl:variable name="total" select="count($selection)" />
+		<xsl:variable name="total" select="count($selection) * ($maxItems = 0) + $maxItems" />
 		<xsl:variable name="lastPageNum" select="ceiling($total div $perPage)" />
 		
 		<xsl:variable name="needToRenderGaps" select="$lastPageNum &gt; 2 * $pageLinksBeside + 4" />

--- a/paginationhelper/_PaginationHelper.xslt
+++ b/paginationhelper/_PaginationHelper.xslt
@@ -111,21 +111,14 @@
 		
 		<xsl:variable name="startIndex" select="$perPage * ($page - 1) + 1" /><!-- First item on this page -->
 		<xsl:variable name="endIndex"><!-- Last item on this page -->
-			<xsl:choose>
-				<xsl:when test="$maxItems = 0">
-					<xsl:value-of select="$page * $perPage" />
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:choose>
-						<xsl:when test="$page * $perPage &gt; $maxItems">
-							<xsl:value-of select="$maxItems" />
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:value-of select="$page * $perPage" />
-						</xsl:otherwise>
-					</xsl:choose>
-				</xsl:otherwise>
-			</xsl:choose>
+			<!--
+				If $maxItems is 0 use page * perPage
+				
+			-->
+			<xsl:value-of select="
+				(($page * $perPage) * (($maxItems = 0) or ($maxItems &gt; ($page * $perPage)))) +
+				(($maxItems) * (($page * $perPage) &gt;= $maxItems))
+			" />
 		</xsl:variable>
 		
 		<xsl:choose>

--- a/paginationhelper/test/PaginationHelperTest.xspec
+++ b/paginationhelper/test/PaginationHelperTest.xspec
@@ -95,10 +95,30 @@
 			<p><a href="...">...</a></p>
 			<p><a href="...">...</a></p>
 			<ul class="pagination">
-			<li class="backwards">...</li>
-			<li>...</li>
-			<li class="active">...</li>
-			<li class="forwards disabled">...</li>
+				<li class="backwards">...</li>
+				<li>...</li>
+				<li class="active">...</li>
+				<li class="forwards disabled">...</li>
+			</ul>
+		</x:expect>
+	</x:scenario>
+	
+	<x:scenario label="when specifying maxItems to PageinateSelection">
+		<x:call template="PaginateSelection">
+			<x:param name="selection" select="document('fixtures/people.xml', /)/people/person" />
+			<x:param name="page" select="2" />
+			<x:param name="perPage" select="7" />
+			<x:param name="maxItems" select="10" />
+		</x:call>
+		<x:expect label="it should fall through to the pager control">
+			<p><a href="...">...</a></p>
+			<p><a href="...">...</a></p>
+			<p><a href="...">...</a></p>
+			<ul class="...">
+				<li class="...">...</li>
+				<li>...</li>
+				<li class="...">...</li>
+				<li class="...">...</li>
 			</ul>
 		</x:expect>
 	</x:scenario>

--- a/paginationhelper/test/PaginationHelperTest.xspec
+++ b/paginationhelper/test/PaginationHelperTest.xspec
@@ -324,6 +324,21 @@
 			</x:expect>
 		</x:scenario>
 		
+		<x:scenario label="then specifying maxItems = 10">
+			<x:call>
+				<x:param name="maxItems" select="10" />
+			</x:call>
+			<x:expect label="it should only render 4 pages">
+				<ul class="pager">
+					<li class="prev disabled">...</li>
+					<li class="current">...</li>
+					<li>...</li>
+					<li>...</li>
+					<li>...</li>
+					<li class="next">...</li>
+				</ul>
+			</x:expect>
+		</x:scenario>
 	</x:scenario>
 	
 	<x:scenario label="when specifying false() for the 'showPager' parameter">
@@ -345,6 +360,19 @@
 			<p><a href="...">...</a></p>
 		</x:expect>
 		<x:expect label="not the pager &lt;ul&gt;" test="not(//ul[@class = 'pager'])" />
+	</x:scenario>
+	
+	<x:scenario label="when specifying 10 for the 'maxItems' parameter with 3 perPage on page 4">
+		<x:call template="PaginateSelection">
+			<x:param name="selection" select="document('fixtures/lots-of-people.xml', /)/people/person" />
+			<x:param name="maxItems" select="10" />
+			<x:param name="perPage" select="3" />
+			<x:param name="page" select="4" />
+			<x:param name="showPager" select="false()" />
+		</x:call>
+		<x:expect label="it should only render the 10th (faked last) person">
+			<p><a href="...">Sun Kwon</a></p>
+		</x:expect>
 	</x:scenario>
 	
 	<x:scenario label="when specifying 5 for the 'perPage' parameter">

--- a/paginationhelper/test/PaginationHelperTest.xspec
+++ b/paginationhelper/test/PaginationHelperTest.xspec
@@ -375,6 +375,64 @@
 		</x:expect>
 	</x:scenario>
 	
+	<x:scenario label="when 'maxItems' is equal to the number of items and you're on the last page'">
+		<x:call template="PaginateSelection">
+			<x:param name="selection" select="document('fixtures/people.xml', /)/people/person" />
+			<x:param name="maxItems" select="14" />
+			<x:param name="perPage" select="7" />
+			<x:param name="page" select="2" />
+			<x:param name="showPager" select="false()" />
+		</x:call>
+		<x:expect label="it should render a complete page">
+			<p><a href="...">James Sawyer</a></p>
+			<p><a href="...">...</a></p>
+			<p><a href="...">Sun Kwon</a></p>
+			<p><a href="...">...</a></p>
+			<p><a href="...">...</a></p>
+			<p><a href="christian.shepard@4815162342x.com">...</a></p>
+			<p><a href="...">Juliet</a></p>
+		</x:expect>
+	</x:scenario>
+	
+	<x:scenario label="when 'maxItems' is larger than the number of items">
+		<x:call template="PaginateSelection">
+			<x:param name="selection" select="document('fixtures/people.xml', /)/people/person" />
+			<x:param name="maxItems" select="20" />
+			<x:param name="perPage" select="7" />
+			<x:param name="showPager" select="false()" />
+		</x:call>
+		
+		<x:scenario label="on page 1">
+			<x:call>
+				<x:param name="page" select="1" />
+			</x:call>
+			<x:expect label="it should render the complete page">
+				<p><a href="...">Jack Shepard</a></p>
+				<p><a href="...">Kate Austen</a></p>
+				<p><a href="...">Hugo Reyes</a></p>
+				<p><a href="...">...</a></p>
+				<p><a href="...">...</a></p>
+				<p><a href="...">...</a></p>
+				<p><a href="...">...</a></p>
+			</x:expect>
+		</x:scenario>
+
+		<x:scenario label="on page 2">
+			<x:call>
+				<x:param name="page" select="2" />
+			</x:call>
+			<x:expect label="it should also render the complete page">
+				<p><a href="...">James Sawyer</a></p>
+				<p><a href="...">...</a></p>
+				<p><a href="...">Sun Kwon</a></p>
+				<p><a href="...">...</a></p>
+				<p><a href="...">...</a></p>
+				<p><a href="christian.shepard@4815162342x.com">...</a></p>
+				<p><a href="...">Juliet</a></p>
+			</x:expect>
+		</x:scenario>
+	</x:scenario>
+	
 	<x:scenario label="when specifying 5 for the 'perPage' parameter">
 		<x:call template="PaginateSelection">
 			<x:param name="selection" select="document('fixtures/people.xml', /)/people/person" />

--- a/version.ent
+++ b/version.ent
@@ -1,8 +1,8 @@
 <!-- Current Versions -->
-<!ENTITY packageVersion "1.2.1">
+<!ENTITY packageVersion "1.2.2">
 <!ENTITY XSLTHelpersVersionHeader "XSLT Helpers v&packageVersion;">
 <!ENTITY MediaHelperVersion "2.0">
-<!ENTITY PaginationHelperVersion "1.7.1">
+<!ENTITY PaginationHelperVersion "1.7.2">
 <!ENTITY GroupingHelperVersion "1.0">
 <!ENTITY CalendarHelperVersion "1.2">
 <!ENTITY NavigationHelperVersion "1.2">


### PR DESCRIPTION
This adds the ability to specify a maximum number of items to render in total (e.g., even if there are 2000 items, only render the first 500).